### PR TITLE
Remove the need to pass configuration as a parameter.

### DIFF
--- a/IdentityServer/HostingExtensions.cs
+++ b/IdentityServer/HostingExtensions.cs
@@ -60,14 +60,14 @@ internal static class HostingExtensions
         }
     }
 
-    public static WebApplication ConfigureServices(this WebApplicationBuilder builder, IConfiguration configuration)
+    public static WebApplication ConfigureServices(this WebApplicationBuilder builder)
     {
         // Configure our connections strings object.
-        builder.Services.Configure<ConnectionStrings>(configuration.GetSection(key: ConfigurationSections.ConnectionStrings));
+        builder.Services.Configure<ConnectionStrings>(builder.Configuration.GetSection(key: ConfigurationSections.ConnectionStrings));
 
         // Create a local instance of the options for immediate use.
         var connectionStrings = new ConnectionStrings();
-        configuration.GetSection(ConfigurationSections.ConnectionStrings).Bind(connectionStrings);
+        builder.Configuration.GetSection(ConfigurationSections.ConnectionStrings).Bind(connectionStrings);
 
         builder.Services.AddRazorPages();
 

--- a/IdentityServer/Program.cs
+++ b/IdentityServer/Program.cs
@@ -17,7 +17,7 @@ try
         .ReadFrom.Configuration(ctx.Configuration));
 
     var app = builder
-        .ConfigureServices(builder.Configuration)
+        .ConfigureServices()
         .ConfigurePipeline();
     
     app.Run();


### PR DESCRIPTION
Remove the need to pass the configuration as a parameter when it's already passed through the extension.