### PR TITLE
Changes to both the Client and Server projects

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -5,9 +5,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="8.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
 		<PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="2.1.0" />
 		<PackageReference Include="Duende.BFF" Version="2.2.0" />
+		<PackageReference Include="HealthChecks.Uptime" Version="2.0.3" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.2" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
 	</ItemGroup>
 

--- a/Client/Constants.cs
+++ b/Client/Constants.cs
@@ -3,6 +3,7 @@
 public class ConfigurationSections
 {
     public const string IdentityProvider = "IdentityProvider";
+    public const string Licenses = "Licenses";
 }
 
 public static class OpenIdConnectScopes

--- a/Client/Controllers/HomeController.cs
+++ b/Client/Controllers/HomeController.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,6 +12,15 @@ public class HomeController() : Controller
 
     public IActionResult Secure() => View();
 
-    public IActionResult Logout() => SignOut("oidc", "cookie");
+    public IActionResult Logout() => SignOut(OpenIdConnectDefaults.AuthenticationScheme, CookieAuthenticationDefaults.AuthenticationScheme);
+
+    [AllowAnonymous]
+    public IActionResult AccessDenied() => View();
+
+    [AllowAnonymous]
+    public IActionResult Error() => View();
+
+    [AllowAnonymous]
+    public IActionResult LoggedOut() => View();
 
 }

--- a/Client/Options/LicensesOptions.cs
+++ b/Client/Options/LicensesOptions.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Client.Options;
+
+public class LicensesOptions
+{
+    public string DuendeBFF { get; set; } = String.Empty;
+}

--- a/Client/Views/Home/AccessDenied.cshtml
+++ b/Client/Views/Home/AccessDenied.cshtml
@@ -1,0 +1,7 @@
+﻿@{
+    ViewData["Title"] = "Access Denied";
+}
+
+<div class="alert alert-danger" role="alert">
+    Access Denied from Identity Provider.
+</div>

--- a/Client/Views/Home/Error.cshtml
+++ b/Client/Views/Home/Error.cshtml
@@ -1,0 +1,7 @@
+﻿@{
+    ViewData["Title"] = "Error";
+}
+
+<div class="alert alert-danger" role="alert">
+    Remote Failure from Identity Provider.
+</div>

--- a/Client/Views/Home/LoggedOut.cshtml
+++ b/Client/Views/Home/LoggedOut.cshtml
@@ -1,0 +1,7 @@
+﻿@{
+    ViewData["Title"] = "Logged Out";
+}
+
+<div class="alert alert-info" role="alert">
+    Logged Out
+</div>

--- a/Client/Views/Shared/_Layout.cshtml
+++ b/Client/Views/Shared/_Layout.cshtml
@@ -28,9 +28,6 @@
                         @if (User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="CallApi">Call API</a>
-                            </li>
-                            <li class="nav-item">
                                 <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Logout">Logout</a>
                             </li>
                         }
@@ -41,6 +38,19 @@
     </header>
     <div class="container">
         <main role="main" class="pb-3">
+
+            @if (User.Identity.IsAuthenticated)
+            {
+                <div class="alert alert-success px-2 py-1" role="alert">
+                    You are authenticated.
+                </div>
+            } else
+            {
+                <div class="alert alert-light px-2 py-1" role="alert">
+                    You are not authenticated.
+                </div>
+            }
+
             @RenderBody()
         </main>
     </div>

--- a/Client/appsettings.json
+++ b/Client/appsettings.json
@@ -3,5 +3,8 @@
     "Authority": "https://localhost:5001",
     "ClientId": "mvc.par",
     "ClientSecret": "secret"
+  },
+  "Licenses": {
+    "DuendeBFF": ""
   }
 }

--- a/IdentityServer/Constants.cs
+++ b/IdentityServer/Constants.cs
@@ -3,4 +3,5 @@
 public class ConfigurationSections
 {
     public const string ConnectionStrings = "ConnectionStrings";
+    public const string ApplicationKeys = "ApplicationKeys";
 }

--- a/IdentityServer/IdentityServer.csproj
+++ b/IdentityServer/IdentityServer.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
     <PackageReference Include="Duende.IdentityServer" Version="7.0.1" />
-    <PackageReference Include="HealthChecks.Uptime" Version="2.0.2" />
+    <PackageReference Include="HealthChecks.Uptime" Version="2.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2">

--- a/IdentityServer/Options/ApplicationKeys.cs
+++ b/IdentityServer/Options/ApplicationKeys.cs
@@ -1,0 +1,6 @@
+﻿namespace IdentityServer.Options;
+
+public class ApplicationKeys : ICustomOptions
+{
+    public string IdentityServer { get; set; } = string.Empty;
+}

--- a/IdentityServer/Options/ConnectionStrings.cs
+++ b/IdentityServer/Options/ConnectionStrings.cs
@@ -1,6 +1,6 @@
 ﻿namespace IdentityServer.Options;
 
-public class ConnectionStrings
+public class ConnectionStrings : ICustomOptions
 {
     public string SqlServer { get; set; } = String.Empty;
 }

--- a/IdentityServer/Options/ICustomOptions.cs
+++ b/IdentityServer/Options/ICustomOptions.cs
@@ -1,0 +1,5 @@
+﻿namespace IdentityServer.Options;
+
+public interface ICustomOptions
+{
+}

--- a/IdentityServer/Options/OptionsExtensions.cs
+++ b/IdentityServer/Options/OptionsExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace IdentityServer.Options;
+
+public static class OptionsExtensions
+{
+    /// <summary>
+    /// Retrieves a custom configuration section from an application's configuration and binds it to a strongly typed object.
+    /// </summary>
+    /// <typeparam name="T">The type of the custom options class to bind to, which must implement the <see cref="ICustomOptions"/> interface and have a parameterless constructor.</typeparam>
+    /// <param name="builder">The <see cref="WebApplicationBuilder"/> instance used to build the web application.</param>
+    /// <param name="configurationSectionName">The name of the configuration section in the application's configuration files (e.g., appsettings.json) that contains the settings to be bound to the custom options class.</param>
+    /// <returns>An instance of the specified custom options class <typeparamref name="T"/>, with its properties populated from the specified configuration section.</returns>
+    /// <remarks>
+    /// This method creates a new instance of the custom options class and uses the <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> available in <paramref name="builder"/> to bind the configuration values from the specified section to the properties of the class.
+    /// </remarks>
+    public static T GetCustomOptionsConfiguration<T>(this WebApplicationBuilder builder, string configurationSectionName) where T : class, ICustomOptions, new()
+    {
+        var optionsClass = Activator.CreateInstance<T>();
+        builder.Configuration.GetSection(configurationSectionName).Bind(optionsClass);
+
+        return optionsClass;
+    }
+}

--- a/IdentityServer/Pages/Account/Logout/LogoutOptions.cs
+++ b/IdentityServer/Pages/Account/Logout/LogoutOptions.cs
@@ -3,6 +3,6 @@ namespace IdentityServerHost.Pages.Logout;
 
 public class LogoutOptions
 {
-    public static bool ShowLogoutPrompt = true;
-    public static bool AutomaticRedirectAfterSignOut = false;
+    public static bool ShowLogoutPrompt = false;
+    public static bool AutomaticRedirectAfterSignOut = true;
 }

--- a/IdentityServer/Program.cs
+++ b/IdentityServer/Program.cs
@@ -12,7 +12,8 @@ try
 {
     var builder = WebApplication.CreateBuilder(args);
 
-    builder.Host.UseSerilog((ctx, lc) => lc
+    builder
+        .Host.UseSerilog((ctx, lc) => lc
         .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
         .Enrich.FromLogContext()
         .ReadFrom.Configuration(ctx.Configuration));
@@ -23,12 +24,7 @@ try
     
     app.Run();
 }
-catch (Exception ex) when (
-    // https://github.com/dotnet/runtime/issues/60600
-    ex.GetType().Name is not "StopTheHostException"
-    // HostAbortedException was added in .NET 7, but since we target .NET 6 we
-    // need to do it this way until we target .NET 8
-    && ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/IdentityServer/appsettings.json
+++ b/IdentityServer/appsettings.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "SqlServer": "Data Source=.;Initial Catalog=Duende.IdentityServer;Integrated Security=True;Connect Timeout=30;Encrypt=True;TrustServerCertificate=True;ApplicationIntent=ReadWrite;MultiSubnetFailover=False"
   },
+  "ApplicationKeys": {
+    "IdentityServer": ""
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",


### PR DESCRIPTION
## Client Changes
The following changes were made to the sample Client application:
- Added HealthChecks (including Uptime & OpenIdConnect integrations).
- Added new configuration section to hold license information (includes the options class `LicenseOptions`)
- Added Duende BFF package to allow server-side initiated logouts to be communicated to the client.
- Added new endpoints in `HomeController.cs` to handle Remote Error, Access Denied and Logged Out events.
- Extended the `ParOidcEvents` class to include handling Remote Error, Access Denied and Logged Out events.
- Minor update to the `_Layout.cshtml` view to indicate whether a user is currently authenticated or not.
- Swapped out magic strings in the `Startup.cs` for appropriate constants.
- Ensured that client secret for PAR is loaded from `IOptions<IdentityProviderOptions>` and not a hardcoded string.

## Identity Server Changes
The following changes were made to the sample Identity Server:
- `InitializeDatabase(...)` changed to extension method and given option to run or not run the seeding steps.
- DI registration for `ConnectionStrings` was redundant and so removed.
- Local instances of `ConnectionStrings` and `ApplicationKeys` created using new `GetCustomOptionsConfiguration` extension method.
- Updated version of `HealthChecks.Uptime` to latest for .NET 8.
- Switched the default values for `ShowLogoutPrompt` and `AutomaticRedirectAfterSignOut`
- Removed the guard clauses specific to .NET 6 & 7 in `program.cs` as the project is now fully targeting .NET 8